### PR TITLE
Get API key at runtime, not (dependency) compile time.

### DIFF
--- a/lib/google_maps/request.ex
+++ b/lib/google_maps/request.ex
@@ -3,7 +3,10 @@ defmodule GoogleMaps.Request do
 
   use HTTPoison.Base
 
-  @api_key Application.get_env(:google_maps, :api_key) || System.get_env("GOOGLE_MAPS_API_KEY")
+  defp api_key do
+    Application.get_env(:google_maps, :api_key) || 
+      System.get_env("GOOGLE_MAPS_API_KEY")
+  end
 
   @doc """
   GET an endpoint with param keyword list
@@ -11,7 +14,7 @@ defmodule GoogleMaps.Request do
   @spec get(String.t, keyword()) :: GoogleMaps.Response.t
   def get(endpoint, params) do
     params =
-      [key: @api_key]
+      [key: api_key()]
       |> Keyword.merge(params)
       |> Enum.map(&transform_param/1)
     get("#{endpoint}?#{URI.encode_query(params)}")


### PR DESCRIPTION
Using a module attribute actually bakes the API key into the compiled modules — the API key is hardcoded right in to (say) `_build/dev/lib/google_maps/ebin/Elixir.GoogleMaps.Request.beam`.  You can literally `grep` for your key and it's right there in the binary file.

This has the effect of being unable to change the key at runtime, short of passing it in to every function:

* If setting the API key via application config, any changes are ignored (unless `_build` is wiped out)  because dependencies are not recompiled when the app's config changes.
* If setting the API key via the environment, it must be set at (dependency) compile time, and the value at runtime is ignored.

Moving the configuration to a function instead of an attribute fixes this.  I've confirmed that the key is not baked in any more, and can be easily changed now.

Note that this might be a breaking change for some people who are (presumably without knowing it) relying on this, either because they've changed keys (but haven't fully recompiled) or because they're not setting the environment variable at runtime (but haven't noticed yet).  So it might be worth a version bump at your discretion.