### PR TITLE
Eliminate String.strip deprecation warning.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule GoogleMaps.Mixfile do
   use Mix.Project
 
-  @version File.read!("VERSION") |> String.strip
+  @version File.read!("VERSION") |> String.trim
 
   def project do
     [app: :google_maps,


### PR DESCRIPTION
Had my `mix.exs` pulling direct from Github, but that meant I was getting this deprecation warning every time I ran anything (under Elixir 1.5), so here's a fix. :)