### PR TITLE
initial place_details work

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Elixir wrapper around Google Maps APIs
 - [x] [Geocoding](https://developers.google.com/maps/documentation/geocoding/intro) - Converts between addresses and geographic coordinates.
 - [ ] [Place Add](https://developers.google.com/places/web-service/add-place) - Allows you to supplement the data in Google's Places database with data from your application.
 - [x] [Place Autocomplete](https://developers.google.com/places/web-service/autocomplete) - can be used to automatically fill in the name and/or address of a place as you type.
-- [ ] [Place Details](https://developers.google.com/places/web-service/details) - Returns more detailed information about a specific Place, including user reviews.
+- [x] [Place Details](https://developers.google.com/places/web-service/details) - Returns more detailed information about a specific Place, including user reviews.
 - [ ] [Place Photo](https://developers.google.com/places/web-service/photos) - Gives you access to the millions of Place related photos stored in Google's Place database
 - [x] [Place Nearby Search](https://developers.google.com/places/web-service/search#PlaceSearchRequests) - Returns a list of places within a specified area based on a user's location or search string. (contributed by @distortia)
 - [x] [Query Autocomplete](https://developers.google.com/places/web-service/query) - can be used to provide a query prediction service for text-based geographic searches, by returning suggested queries as you type.
@@ -24,6 +24,7 @@ Elixir wrapper around Google Maps APIs
 - `place_autocomplete/2`
 - `place_query/2`
 - `place_nearby/3`
+- `place_details/2`
 - `get/2`
 
 ## Installation


### PR DESCRIPTION
I wasn't 100% sure how we wanted to handle the `place_details`.

Leveraging what we have for the spec for `place_id` and what we use for `geocode`, I wrote a few methods.

`place_details({:place_id, place_id})`

`place_details("place_id:" <> place_id)`

`place_details(place_id)`

I am not sure if this is the best way to go about it, but I wanted to get the documentation in a good spot.

I also fixed one of my tests, and we have another test that keeps changing it's value that we will have to address.

Thanks!
