### PR TITLE
Fix error when ZERO_RESULTS from gmaps timezone api

### DIFF
--- a/lib/google_maps.ex
+++ b/lib/google_maps.ex
@@ -1385,8 +1385,9 @@ defmodule GoogleMaps do
   ## Returns
 
     This function returns `{:ok, body}` if the request is successful, and
-    Google returns data. The returned body is a map that contains four root
-    elements:
+    Google returns data. It returns either `{:error, status}` or `{:error, status, error_message}`
+    when there is an error, depending if there's an error message or not.
+    The returned body is a map that contains four root elements:
 
     * `dstOffset` The time difference for summer time in seconds.
       This value will be zero if the time zone is not in daylight saving time

--- a/lib/google_maps/response.ex
+++ b/lib/google_maps/response.ex
@@ -10,4 +10,5 @@ defmodule GoogleMaps.Response do
   def wrap({:error, error}), do: {:error, error}
   def wrap({:ok, %{body: %{"status" => "OK"} = body}}), do: {:ok, body}
   def wrap({:ok, %{body: %{"status" => status, "error_message" => error_message}}}), do: {:error, status, error_message}
+  def wrap({:ok, %{body: %{"status" => status}}}), do: {:error, status}
 end

--- a/test/timezone_test.exs
+++ b/test/timezone_test.exs
@@ -13,4 +13,8 @@ defmodule TimezoneTest do
     assert result["rawOffset"]
     assert result["timeZoneId"]
   end
+
+  test "when there is no result" do
+    {:error, "ZERO_RESULTS"} = Maps.timezone({54.0661, -4.7404})
+  end
 end


### PR DESCRIPTION
While using the timezones api, I encountered the following error:

```
** (FunctionClauseError) no function clause matching in GoogleMaps.Response.wrap/1

    The following arguments were given to GoogleMaps.Response.wrap/1:

        # 1
        {:ok,
     %HTTPoison.Response{body: %{"status" => "ZERO_RESULTS"},
      headers: [{"Content-Type", "application/json; charset=UTF-8"},
       ...
      status_code: 200}}

    Attempted function clauses (showing 3 out of 3):

        def wrap({:error, error})
        def wrap({:ok, %{body: %{"status" => "OK"} = body}})
        def wrap({:ok, %{body: %{"status" => status, "error_message" => error_message}}})
```

When a location is not found, the API seems to return `status`, but no `error_message`. This handles this case. I only added it on the docs for `timezone/2` because it seems to be a normal case for this, but would be an exceptional case for other functions.