### PR TITLE
Support for Place Photo API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Elixir wrapper around Google Maps APIs
 - [ ] [Place Add](https://developers.google.com/places/web-service/add-place) - Allows you to supplement the data in Google's Places database with data from your application.
 - [x] [Place Autocomplete](https://developers.google.com/places/web-service/autocomplete) - can be used to automatically fill in the name and/or address of a place as you type.
 - [x] [Place Details](https://developers.google.com/places/web-service/details) - Returns more detailed information about a specific Place, including user reviews.
-- [ ] [Place Photo](https://developers.google.com/places/web-service/photos) - Gives you access to the millions of Place related photos stored in Google's Place database
+- [x] [Place Photo](https://developers.google.com/places/web-service/photos) - Gives you access to the millions of Place related photos stored in Google's Place database
 - [x] [Place Nearby Search](https://developers.google.com/places/web-service/search#PlaceSearchRequests) - Returns a list of places within a specified area based on a user's location or search string. (contributed by @distortia)
 - [x] [Query Autocomplete](https://developers.google.com/places/web-service/query) - can be used to provide a query prediction service for text-based geographic searches, by returning suggested queries as you type.
 - [x] [Timezone](https://developers.google.com/maps/documentation/timezone/intro) - Time zone data for anywhere in the world. (contributed by @uesteibar)
@@ -30,6 +30,7 @@ Elixir wrapper around Google Maps APIs
 - `place_query/2`
 - `place_nearby/3`
 - `place_details/2`
+- `place_photo/4`
 - `timezone/2`
 - `get/2`
 

--- a/lib/google_maps.ex
+++ b/lib/google_maps.ex
@@ -1523,6 +1523,97 @@ defmodule GoogleMaps do
     place_details({:place_id, place_id}, options)
   end
 
+  @doc """
+    Retrieve a photo for a place based on a photo reference.
+
+    The Place Photo service gives you access to the millions of photos stored
+    in the Places database. When you get place information using a Place Details
+    request, photo references will be returned for relevant photographic content.
+    The Nearby Search and Text Search requests also return a single photo reference
+    per place, when relevant. Using the Photo service you can then access the
+    referenced photos and resize the image to the optimal size for your application.
+
+  ## Args:
+  * `photo_reference` — A string identifier that uniquely identifies a photo.
+    Photo references are returned from either a Place Search or Place Details request.
+
+  * `max_width` and `max_height` — Specify the maximum desired width or height, in pixels,
+    of the image returned by the Place Photos service. If the image is smaller than the
+    values specified, the original image will be returned. If the image is larger in
+    either dimension, it will be scaled to match the smaller of the two dimensions,
+    restricted to its original aspect ratio. Both the maxheight and maxwidth properties
+    accept an integer between 1 and 1600. **Default to 1600.**
+
+  ## Options:
+    While no optional parameters for Place Photos exist at the time of writing, the
+    options keyword list supports the `key` parameter in case an explicit API key
+    is to be supplied.
+
+  ## Returns
+
+    This function returns `{:ok, body}` if the request is successful.
+    The returned body is a binary containing jpeg image data.
+
+    If the API key is invalid or the request has exceeded your quota, the function
+    returns `{:error, 403}`.
+
+    Otherwise, if the request is invalid, the return value will be `{:error, 400}`.
+    This likely indicates an incorrect photo reference.
+
+  ## Examples
+
+      # Request with an invalid API key, max_width of 500
+      iex> photo_reference = "CnRtAAAATLZNl354RwP_9UKbQ_5Psy40texXePv4oAlgP4qNEkdIrkyse7rPXYGd9D_Uj1rVsQdWT4oRz4QrYAJNpFX7rzqqMlZw2h2E2y5IKMUZ7ouD_SlcHxYq1yL4KbKUv3qtWgTK0A6QbGh87GB3sscrHRIQiG2RrmU_jF4tENr9wGS_YxoUSSDrYjWmrNfeEHSGSc3FyhNLlBU"
+      iex> GoogleMaps.place_photo(photo_reference, 500, key: "invalid key")
+      {:error, 403}
+
+      # Request with an invalid photo reference, max_width of 500
+      iex> GoogleMaps.place_photo("invalid reference", 500)
+      {:error, 400}
+
+      # Request a photo with default maximum width/height of 1600
+      iex> photo_reference = "CnRtAAAATLZNl354RwP_9UKbQ_5Psy40texXePv4oAlgP4qNEkdIrkyse7rPXYGd9D_Uj1rVsQdWT4oRz4QrYAJNpFX7rzqqMlZw2h2E2y5IKMUZ7ouD_SlcHxYq1yL4KbKUv3qtWgTK0A6QbGh87GB3sscrHRIQiG2RrmU_jF4tENr9wGS_YxoUSSDrYjWmrNfeEHSGSc3FyhNLlBU"
+      iex> {:ok, response} = GoogleMaps.place_photo(photo_reference)
+      iex> is_binary(response)
+      true
+
+      # Request a photo with a maximum height of 100
+      iex> photo_reference = "CnRtAAAATLZNl354RwP_9UKbQ_5Psy40texXePv4oAlgP4qNEkdIrkyse7rPXYGd9D_Uj1rVsQdWT4oRz4QrYAJNpFX7rzqqMlZw2h2E2y5IKMUZ7ouD_SlcHxYq1yL4KbKUv3qtWgTK0A6QbGh87GB3sscrHRIQiG2RrmU_jF4tENr9wGS_YxoUSSDrYjWmrNfeEHSGSc3FyhNLlBU"
+      iex> {:ok, response} = GoogleMaps.place_photo(photo_reference, nil, 100)
+      iex> is_binary(response)
+      true
+  """
+  @spec place_photo(String.t) :: Response.t()
+  @spec place_photo(String.t, integer() | nil) :: Response.t()
+  @spec place_photo(String.t, integer() | nil, options()) :: Response.t()
+  @spec place_photo(String.t, integer() | nil, integer() | nil) :: Response.t()
+  @spec place_photo(String.t, integer() | nil, integer() | nil, options()) :: Response.t()
+  def place_photo(photo_reference, max_width \\ nil) do
+    place_photo(photo_reference, max_width, nil, [])
+  end
+
+  def place_photo(photo_reference, max_width, opts) when is_list(opts) do
+    place_photo(photo_reference, max_width, nil, opts)
+  end
+
+  def place_photo(photo_reference, max_width, max_height) do
+    place_photo(photo_reference, max_width, max_height, [])
+  end
+
+  def place_photo(photo_reference, max_width, max_height, opts)
+  when is_binary(photo_reference)
+  and is_nil(max_width) or (is_integer(max_width) and max_width >= 1 and max_width <= 1600)
+  and is_nil(max_height) or (is_integer(max_height) and max_height >=1 and max_height <= 1600)
+  and is_list(opts)
+  do
+    params = Keyword.merge(opts, [photoreference: photo_reference,
+                                  maxwidth: max_width || 1600,
+                                  maxheight: max_height || 1600,
+                                  output: "",
+                                  options: [follow_redirect: true]])
+
+    GoogleMaps.get("place/photo", params)
+  end
 
   @doc """
     A Timezone request returns timezone information for the given location.

--- a/lib/google_maps/request.ex
+++ b/lib/google_maps/request.ex
@@ -7,6 +7,7 @@ defmodule GoogleMaps.Request do
   @spec get(String.t, keyword()) :: GoogleMaps.Response.t
   def get(endpoint, params) do
     {secure, params} = Keyword.pop(params, :secure)
+    {output, params} = Keyword.pop(params, :output, "json")
     {key, params} = Keyword.pop(params, :key, api_key())
     {headers, params} = Keyword.pop(params, :headers, [])
     {options, params} = Keyword.pop(params, :options, [])
@@ -20,9 +21,10 @@ defmodule GoogleMaps.Request do
       |> Enum.map(&transform_param/1)
       |> URI.encode_query()
 
-    url = "https://maps.googleapis.com/maps/api/#{endpoint}/json"
+    url = Path.join("https://maps.googleapis.com/maps/api/#{endpoint}", output)
 
     requester().get("#{url}?#{query}", headers, options)
+    |> format_headers()
   end
 
   # Helpers
@@ -65,4 +67,10 @@ defmodule GoogleMaps.Request do
   end
 
   defp transform_param(param), do: param
+
+  defp format_headers({:ok, %{headers: headers} = response}) do
+    {:ok, %{response | headers: Map.new(headers)}}
+  end
+
+  defp format_headers(error), do: error
 end

--- a/lib/google_maps/response.ex
+++ b/lib/google_maps/response.ex
@@ -8,10 +8,14 @@ defmodule GoogleMaps.Response do
   @type error :: HTTPoison.Error.t | status()
 
   def wrap({:error, error}), do: {:error, error}
-  def wrap({:ok, %{body: body} = response}) when is_binary(body) do
+  def wrap({:ok, %{body: body, headers: %{"Content-Type" => "application/json" <> _}} = response})
+  when is_binary(body) do
     wrap({:ok, %{response | body: Jason.decode!(body)}})
   end
   def wrap({:ok, %{body: %{"status" => "OK"} = body}}), do: {:ok, body}
   def wrap({:ok, %{body: %{"status" => status, "error_message" => error_message}}}), do: {:error, status, error_message}
   def wrap({:ok, %{body: %{"status" => status}}}), do: {:error, status}
+  def wrap({:ok, %{body: body, status_code: 200, headers: %{"Content-Type" => "image" <> _}}})
+  when is_binary(body), do: {:ok, body}
+  def wrap({:ok, %{status_code: status, headers: %{"Content-Type" => _}}}), do: {:error, status}
 end

--- a/test/google_maps/request_test.exs
+++ b/test/google_maps/request_test.exs
@@ -36,7 +36,7 @@ defmodule GoogleMaps.RequestTest do
   end
 
   test "supports headers" do
-    params = [headers: [{"Accept-Language", "vi"}]]
+    params = [headers: %{"Accept-Language" => "vi"}]
     {:ok, %{headers: headers}} = Request.get("foobar", params)
     assert headers === params[:headers]
   end


### PR DESCRIPTION
Here's a take on the [Place Photo API](https://developers.google.com/places/web-service/photos)!

Key changes:

- Updated README.
- Added a `place_photo/3` wrapper to `GoogleMaps.get/2` with doctests.
- Added an optional `:resource` param to `GoogleMaps.Request.get/2` to determine what will be appended to the resulting request URL. This was necessary to support non-JSON endpoints such as this one. Defaults to "json".
- Because Place Photo requests return binary image data, they could not be decoded as JSON in `GoogleMaps.Response.wrap/2`. Thus, the `:resource` param also plays a role in defining how the response is formatted to the user.